### PR TITLE
Avoid floating point differences with Python SpatialPooler

### DIFF
--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1122,43 +1122,40 @@ namespace {
 
     Real initActiveDutyCycles1[] = {0.1, 0.1, 0.1, 0.1, 0.1, 0.1};
     Real initBoostFactors1[] = {0, 0, 0, 0, 0, 0};
-    Real trueBoostFactors1[] = {1, 1, 1, 1, 1, 1};
-    Real resultBoostFactors1[6];
+    vector<Real> trueBoostFactors1 =
+      {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    vector<Real> resultBoostFactors1(6, 0);
     sp.setGlobalInhibition(false);
     sp.setMaxBoost(10);
     sp.setBoostFactors(initBoostFactors1);
     sp.setActiveDutyCycles(initActiveDutyCycles1);
     sp.updateBoostFactors_();
-    sp.getBoostFactors(resultBoostFactors1);
-    ASSERT_TRUE(check_vector_eq(trueBoostFactors1, resultBoostFactors1, 6));
+    sp.getBoostFactors(resultBoostFactors1.data());
+    ASSERT_EQ(trueBoostFactors1, resultBoostFactors1);
 
     Real initActiveDutyCycles2[] =
       {0.1, 0.3, 0.02, 0.04, 0.7, 0.12};
     Real initBoostFactors2[] =
       {0, 0, 0, 0, 0, 0};
-    Real trueBoostFactors2[] =
-      {3.105992732789097, 0.42035040622287317,
-      6.9125139504223041, 5.659487752291307,
-      0.0076989862471108653, 2.5429717691711562};
-
-    Real resultBoostFactors2[6];
+    vector<Real> trueBoostFactors2 =
+      {3.11, 0.42, 6.91, 5.66, 0.01, 2.54};
+    vector<Real> resultBoostFactors2(6, 0);
     sp.setGlobalInhibition(false);
     sp.setMaxBoost(10);
     sp.setBoostFactors(initBoostFactors2);
     sp.setActiveDutyCycles(initActiveDutyCycles2);
     sp.updateBoostFactors_();
-    sp.getBoostFactors(resultBoostFactors2);
-    ASSERT_TRUE(check_vector_eq(trueBoostFactors2, resultBoostFactors2, 6));
+    sp.getBoostFactors(resultBoostFactors2.data());
+
+    ASSERT_EQ(trueBoostFactors2, resultBoostFactors2);
 
     Real initActiveDutyCycles3[] =
       {0.1, 0.3, 0.02, 0.04, 0.7, 0.12};
     Real initBoostFactors3[] =
       {0, 0, 0, 0, 0, 0};
-    Real trueBoostFactors3[] =
-      {1.2544116739825764, 0.84085729105164408,
-      1.472065736117588, 1.4143452129997691,
-      0.37782153555864834, 1.2052254887118465};
-    Real resultBoostFactors3[6];
+    vector<Real> trueBoostFactors3 =
+      {1.25, 0.84, 1.47, 1.41, 0.38, 1.21};
+    vector<Real> resultBoostFactors3(6, 0);
     sp.setWrapAround(true);
     sp.setGlobalInhibition(false);
     sp.setMaxBoost(2.0);
@@ -1167,19 +1164,17 @@ namespace {
     sp.setBoostFactors(initBoostFactors3);
     sp.setActiveDutyCycles(initActiveDutyCycles3);
     sp.updateBoostFactors_();
-    sp.getBoostFactors(resultBoostFactors3);
+    sp.getBoostFactors(resultBoostFactors3.data());
 
-    ASSERT_TRUE(check_vector_eq(trueBoostFactors3, resultBoostFactors3, 6));
+    ASSERT_EQ(trueBoostFactors3, resultBoostFactors3);
 
     Real initActiveDutyCycles4[] =
       {0.1, 0.3, 0.02, 0.04, 0.7, 0.12};
     Real initBoostFactors4[] =
       {0, 0, 0, 0, 0, 0};
-    Real trueBoostFactors4[] =
-      {1.9477340410546755, 0.26359713811572677,
-      4.3347618261852094, 3.5490028143663039,
-      0.0048279499938314414, 1.5946697582283156};
-    Real resultBoostFactors4[6];
+    vector<Real> trueBoostFactors4 =
+      {1.95, 0.26, 4.33, 3.55, 0.00, 1.59};
+    vector<Real> resultBoostFactors4(6, 0);
     sp.setGlobalInhibition(true);
     sp.setMaxBoost(10);
     sp.setNumActiveColumnsPerInhArea(1);
@@ -1187,8 +1182,9 @@ namespace {
     sp.setBoostFactors(initBoostFactors4);
     sp.setActiveDutyCycles(initActiveDutyCycles4);
     sp.updateBoostFactors_();
-    sp.getBoostFactors(resultBoostFactors4);
-    ASSERT_TRUE(check_vector_eq(trueBoostFactors4, resultBoostFactors4, 6));
+    sp.getBoostFactors(resultBoostFactors4.data());
+
+    ASSERT_EQ(trueBoostFactors4, resultBoostFactors4);
   }
 
   TEST(SpatialPoolerTest, testUpdateBookeepingVars)


### PR DESCRIPTION
This fixes the spatial pooler compatibility test. It requires a similar change in the Python code: https://github.com/ywcui1990/nupic/pull/1

For permanances, use an EPSILON.

For boosting, round the boost factor to a couple decimal places. Floating point differences have a larger effect on boosting because it's multiplicative.